### PR TITLE
Added teleport by CTRL+Shift+click on minimap or on Cyclopedia map (#…

### DIFF
--- a/data/XML/groups.xml
+++ b/data/XML/groups.xml
@@ -56,6 +56,9 @@
 			<flag cannotbemuted="1" />
 			<flag isalwayspremium="1" />
 		</flags>
+		<customflags>
+			<customflag canmapclickteleport="0" />
+		</customflags>
 	</group>
 	<group id="5" name="community manager" access="1" maxdepotitems="0" maxvipentries="200">
 		<flags>
@@ -98,6 +101,9 @@
 			<flag cannotbemuted="1" />
 			<flag isalwayspremium="1" />
 		</flags>
+		<customflags>
+			<customflag canmapclickteleport="0" />
+		</customflags>
 	</group>
 	<group id="6" name="god" access="1" maxdepotitems="0" maxvipentries="200">
 		<flags>
@@ -140,5 +146,8 @@
 			<flag cannotbemuted="1" />
 			<flag isalwayspremium="1" />
 		</flags>
+		<customflags>
+			<customflag canmapclickteleport="1" />
+		</customflags>
 	</group>
 </groups>

--- a/data/lib/core/player.lua
+++ b/data/lib/core/player.lua
@@ -37,6 +37,10 @@ function Player.hasFlag(self, flag)
 	return self:getGroup():hasFlag(flag)
 end
 
+function Player.hasCustomFlag(self, customflag)
+	return self:getGroup():hasCustomFlag(customflag)
+end
+
 function Player.isPremium(self)
 	return self:getPremiumDays() > 0 or configManager.getBoolean(configKeys.FREE_PREMIUM)
 end

--- a/src/const.h
+++ b/src/const.h
@@ -644,6 +644,10 @@ enum PlayerFlags : uint64_t {
 	PlayerFlag_IsAlwaysPremium = static_cast<uint64_t>(1) << 37,
 };
 
+enum PlayerCustomFlags : uint64_t {
+  PlayerCustomFlag_CanMapClickTeleport = 1 << 0,
+};
+
 enum ReloadTypes_t : uint8_t  {
 	RELOAD_TYPE_ALL,
 	RELOAD_TYPE_ACTIONS,

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -679,6 +679,18 @@ void Game::executeDeath(uint32_t creatureId)
 	}
 }
 
+void Game::playerTeleport(uint32_t playerId, const Position& newPosition) {
+  Player* player = getPlayerByID(playerId);
+  if (!player || !player->hasCustomFlag(PlayerCustomFlag_CanMapClickTeleport)) {
+    return;
+  }
+
+  ReturnValue returnValue = g_game.internalTeleport(player, newPosition, false);
+  if (returnValue != RETURNVALUE_NOERROR) {
+    player->sendCancelMessage(returnValue);
+  }
+}
+
 void Game::playerMoveThing(uint32_t playerId, const Position& fromPos,
                            uint16_t spriteId, uint8_t fromStackPos, const Position& toPos, uint8_t count)
 {

--- a/src/game.h
+++ b/src/game.h
@@ -337,6 +337,7 @@ class Game
 		void broadcastMessage(const std::string& text, MessageClasses type) const;
 
 		//Implementation of player invoked events
+    void playerTeleport(uint32_t playerId, const Position& pos);
 		void playerMoveThing(uint32_t playerId, const Position& fromPos, uint16_t spriteId, uint8_t fromStackPos,
 							 const Position& toPos, uint8_t count);
 		void playerMoveCreatureByID(uint32_t playerId, uint32_t movingCreatureId, const Position& movingCreatureOrigPos, const Position& toPos);

--- a/src/groups.cpp
+++ b/src/groups.cpp
@@ -65,6 +65,10 @@ const std::unordered_map<std::string, PlayerFlags> ParsePlayerFlagMap = {
 	{"isalwayspremium", PlayerFlag_IsAlwaysPremium}
 };
 
+const std::unordered_map<std::string, PlayerCustomFlags> ParsePlayerCustomFlagMap = {
+  {"canmapclickteleport", PlayerCustomFlag_CanMapClickTeleport}
+};
+
 bool Groups::load()
 {
 	pugi::xml_document doc;
@@ -92,6 +96,20 @@ bool Groups::load()
 				auto parseFlag = ParsePlayerFlagMap.find(attr.name());
 				if (parseFlag != ParsePlayerFlagMap.end()) {
 					group.flags |= parseFlag->second;
+				}
+			}
+		}
+    group.customflags = pugi::cast<uint64_t>(groupNode.attribute("customflags").value());
+    if (pugi::xml_node node = groupNode.child("customflags")) {
+      for (auto customflagNode : node.children()) {
+				pugi::xml_attribute attr = customflagNode.first_attribute();
+				if (!attr || (attr && !attr.as_bool())) {
+					continue;
+				}
+
+				auto parseCustomFlag = ParsePlayerCustomFlagMap.find(attr.name());
+				if (parseCustomFlag != ParsePlayerCustomFlagMap.end()) {
+					group.customflags |= parseCustomFlag->second;
 				}
 			}
 		}

--- a/src/groups.h
+++ b/src/groups.h
@@ -23,6 +23,7 @@
 struct Group {
 	std::string name;
 	uint64_t flags;
+	uint64_t customflags;
 	uint32_t maxDepotItems;
 	uint32_t maxVipEntries;
 	uint16_t id;

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -1639,6 +1639,8 @@ void LuaScriptInterface::registerFunctions()
 	registerEnum(PlayerFlag_CannotBeMuted)
 	registerEnum(PlayerFlag_IsAlwaysPremium)
 
+	registerEnum(PlayerCustomFlag_CanMapClickTeleport)
+
 	registerEnum(PLAYERSEX_FEMALE)
 	registerEnum(PLAYERSEX_MALE)
 
@@ -2727,10 +2729,12 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("Group", "getId", LuaScriptInterface::luaGroupGetId);
 	registerMethod("Group", "getName", LuaScriptInterface::luaGroupGetName);
 	registerMethod("Group", "getFlags", LuaScriptInterface::luaGroupGetFlags);
+	registerMethod("Group", "getCustomFlags", LuaScriptInterface::luaGroupGetCustomFlags);
 	registerMethod("Group", "getAccess", LuaScriptInterface::luaGroupGetAccess);
 	registerMethod("Group", "getMaxDepotItems", LuaScriptInterface::luaGroupGetMaxDepotItems);
 	registerMethod("Group", "getMaxVipEntries", LuaScriptInterface::luaGroupGetMaxVipEntries);
 	registerMethod("Group", "hasFlag", LuaScriptInterface::luaGroupHasFlag);
+	registerMethod("Group", "hasCustomFlag", LuaScriptInterface::luaGroupHasCustomFlag);
 
 	// Vocation
 	registerClass("Vocation", "", LuaScriptInterface::luaVocationCreate);
@@ -12164,6 +12168,18 @@ int LuaScriptInterface::luaGroupGetFlags(lua_State* L)
 	return 1;
 }
 
+int LuaScriptInterface::luaGroupGetCustomFlags(lua_State* L)
+{
+	// group:getCustomFlags()
+	Group* group = getUserdata<Group>(L, 1);
+	if (group) {
+		lua_pushnumber(L, group->customflags);
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
 int LuaScriptInterface::luaGroupGetAccess(lua_State* L)
 {
 	// group:getAccess()
@@ -12207,6 +12223,19 @@ int LuaScriptInterface::luaGroupHasFlag(lua_State* L)
 	if (group) {
 		PlayerFlags flag = getNumber<PlayerFlags>(L, 2);
 		pushBoolean(L, (group->flags & flag) != 0);
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaGroupHasCustomFlag(lua_State* L)
+{
+	// group:hasCustomFlag(flag)
+	Group* group = getUserdata<Group>(L, 1);
+	if (group) {
+		PlayerCustomFlags customflag = getNumber<PlayerCustomFlags>(L, 2);
+		pushBoolean(L, (group->customflags & customflag) != 0);
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -1154,10 +1154,12 @@ class LuaScriptInterface
 		static int luaGroupGetId(lua_State* L);
 		static int luaGroupGetName(lua_State* L);
 		static int luaGroupGetFlags(lua_State* L);
+		static int luaGroupGetCustomFlags(lua_State* L);
 		static int luaGroupGetAccess(lua_State* L);
 		static int luaGroupGetMaxDepotItems(lua_State* L);
 		static int luaGroupGetMaxVipEntries(lua_State* L);
 		static int luaGroupHasFlag(lua_State* L);
+		static int luaGroupHasCustomFlag(lua_State* L);
 
 		// Vocation
 		static int luaVocationCreate(lua_State* L);

--- a/src/player.h
+++ b/src/player.h
@@ -389,6 +389,10 @@ class Player final : public Creature, public Cylinder
 			return (group->flags & value) != 0;
 		}
 
+		bool hasCustomFlag(PlayerCustomFlags value) const {
+			return (group->customflags & value) != 0;
+		}
+
 		BedItem* getBedItem() {
 			return bedItem;
 		}

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -433,6 +433,7 @@ void ProtocolGame::parsePacket(NetworkMessage& msg)
 		case 0x70: addGameTaskTimed(DISPATCHER_TASK_EXPIRATION, &Game::playerTurn, player->getID(), DIRECTION_EAST); break;
 		case 0x71: addGameTaskTimed(DISPATCHER_TASK_EXPIRATION, &Game::playerTurn, player->getID(), DIRECTION_SOUTH); break;
 		case 0x72: addGameTaskTimed(DISPATCHER_TASK_EXPIRATION, &Game::playerTurn, player->getID(), DIRECTION_WEST); break;
+		case 0x73: parseTeleport(msg); break;
 		case 0x78: parseThrow(msg); break;
 		case 0x79: parseLookInShop(msg); break;
 		case 0x7A: parsePlayerPurchase(msg); break;
@@ -879,6 +880,12 @@ void ProtocolGame::parseUpdateContainer(NetworkMessage& msg)
 {
 	uint8_t cid = msg.getByte();
 	addGameTask(&Game::playerUpdateContainer, player->getID(), cid);
+}
+
+void ProtocolGame::parseTeleport(NetworkMessage& msg)
+{
+	Position newPosition = msg.getPosition();
+	addGameTask(&Game::playerTeleport, player->getID(), newPosition);
 }
 
 void ProtocolGame::parseThrow(NetworkMessage& msg)

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -112,6 +112,7 @@ class ProtocolGame final : public Protocol
 		void parseDebugAssert(NetworkMessage& msg);
 		void parseRuleViolationReport(NetworkMessage &msg);
 
+		void parseTeleport(NetworkMessage& msg);
 		void parseThrow(NetworkMessage& msg);
 		void parseUseItemEx(NetworkMessage& msg);
 		void parseUseWithCreature(NetworkMessage& msg);


### PR DESCRIPTION
…1607)

Added teleport by CTRL+Shift+click on minimap or on Cyclopedia map.

Also there's a new custom flag on groups.xml to define which groups can use this feature so server owners don't need to edit source files to change that.

About why implementing custom player flags instead of a new player flag: this is meant to keep compatibility with TFS, so even if new player flags get added on it we will not be forced to add them with different exponential values than on TFS and we will not mix original flags with flags added for new features on OTServBR-Global like this one.

IMPORTANT NOTE:
All credits to this new feature should go to @jo3bingham and his post on OTLand. I merely added his code to OTServBR-Global source and created a custom flag for easier configuration for server owners.