### PR TITLE
Correção no final da Inquisition Quest (#1757)

### DIFF
--- a/data/actions/actions.xml
+++ b/data/actions/actions.xml
@@ -277,7 +277,6 @@
 	<action fromaid="23700" toaid="23701" script="quests/in_service_of_yalahar/yalahar_machine_war_golems.lua" />
 	<!-- inquisition quest -->
 	<action fromuid="1006" touid="1009" script="quests/inquisition/brother_lever.lua" />
-	<action itemid="8753" script="quests/inquisition/mw.lua" />
 	<action fromuid="1300" touid="1308" script="quests/inquisition/rewards.lua" />
 	<action actionid="1004" script="quests/inquisition/ungreez_door.lua" />
 	<action actionid="2002" script="quests/inquisition/vampire_hunt.lua" />

--- a/data/actions/scripts/quests/others/holy_water.lua
+++ b/data/actions/scripts/quests/others/holy_water.lua
@@ -38,10 +38,10 @@ local storages = {
 	[4023] = Storage.TibiaTales.RestInHallowedGround.Graves.Grave16
 }
 
-local config = { 
+local config = {
 	antler_talisman = 24664,
 	sacred_antler_talisman = 24665
-	}
+}
 
 function onUse(player, item, fromPosition, target, toPosition, isHotkey)
 
@@ -63,7 +63,7 @@ function onUse(player, item, fromPosition, target, toPosition, isHotkey)
 		player:setStorageValue(Storage.TheInquisition.Questline, 5)
 		return true
 
-	-- Haunted Ruin
+		-- Haunted Ruin
 	elseif target.actionid == 2003 then
 		if player:getStorageValue(Storage.TheInquisition.Questline) ~= 12 then
 			return true
@@ -84,30 +84,10 @@ function onUse(player, item, fromPosition, target, toPosition, isHotkey)
 		return true
 	end
 
-	-- Shadow Nexus
-	if isInArray({8753, 8755, 8757}, target.itemid) then
-		target:transform(target.itemid + 1)
-		target:decay()
-		nexusMessage(player, player:getName() .. ' damaged the shadow nexus! You can\'t damage it while it\'s burning.')
-		shadowNexusPosition:sendMagicEffect(CONST_ME_HOLYAREA)
-
-	elseif target.itemid == 8759 then
-		if player:getStorageValue(Storage.TheInquisition.Questline) < 22 then
-			-- The Inquisition Questlog- 'Mission 7: The Shadow Nexus'
-			player:setStorageValue(Storage.TheInquisition.Mission07, 2)
-			player:setStorageValue(Storage.TheInquisition.Questline, 22)
-		end
-
-		for i = 1, #effectPositions do
-			effectPositions[i]:sendMagicEffect(CONST_ME_HOLYAREA)
-		end
-
-		nexusMessage(player, player:getName() .. ' destroyed the shadow nexus! In 20 seconds it will return to its original state.')
-		item:remove(1)
-	elseif target.actionid == 4007 and target.actionid == 4024 then
+	if target.actionid == 4007 and target.actionid == 4024 then
 		local graveStorage = storages[target.actionid]
 		if player:getStorageValue(graveStorage) == 1
-				or player:getStorageValue(Storage.TibiaTales.RestInHallowedGround.Questline) ~= 3 then
+		or player:getStorageValue(Storage.TibiaTales.RestInHallowedGround.Questline) ~= 3 then
 			return false
 		end
 
@@ -124,5 +104,35 @@ function onUse(player, item, fromPosition, target, toPosition, isHotkey)
 
 		toPosition:sendMagicEffect(CONST_ME_MAGIC_BLUE)
 	end
+
+	-- Shadow Nexus
+	if isInArray({8753, 8755, 8757}, target.itemid) then
+		if target.itemid == 8757 then
+			Game.setStorageValue(GlobalStorage.Inquisition, math.random(4,5))
+		end
+		target:transform(target.itemid + 1)
+		target:setAttribute(ITEM_ATTRIBUTE_DURATION, 20000)
+		target:decay()
+		nexusMessage(player, player:getName() .. ' damaged the shadow nexus! You can\'t damage it while it\'s burning.')
+		toPosition:sendMagicEffect(CONST_ME_ENERGYHIT)
+	elseif target.itemid == 8759 then
+		if Game.getStorageValue(GlobalStorage.Inquisition) > 0 then
+			Game.setStorageValue(GlobalStorage.Inquisition, (Game.getStorageValue(GlobalStorage.Inquisition)-1))
+			if player:getStorageValue(Storage.TheInquisition.Questline) < 22 then
+				-- The Inquisition Questlog- 'Mission 7: The Shadow Nexus'
+				player:setStorageValue(Storage.TheInquisition.Mission07, 2)
+				player:setStorageValue(Storage.TheInquisition.Questline, 22)
+			end
+			for i = 1, #effectPositions do
+				effectPositions[i]:sendMagicEffect(CONST_ME_HOLYAREA)
+			end
+			nexusMessage(player, player:getName() .. ' destroyed the shadow nexus! In 10 seconds it will return to its original state.')
+			item:remove(1)
+			toPosition:sendMagicEffect(CONST_ME_HOLYAREA)
+		else
+			target:transform(8753)
+		end
+	end
+
 	return true
 end

--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -16534,27 +16534,27 @@
 	<item id="8753" article="the" name="shadow nexus" />
 	<item id="8754" article="the" name="shadow nexus">
 		<attribute key="decayTo" value="8755" />
-		<attribute key="duration" value="30" />
+		<attribute key="duration" value="20" />
 	</item>
 	<item id="8755" article="the" name="shadow nexus">
 		<attribute key="decayTo" value="8753" />
-		<attribute key="duration" value="20" />
+		<attribute key="duration" value="300" />
 	</item>
 	<item id="8756" article="the" name="shadow nexus">
 		<attribute key="decayTo" value="8757" />
-		<attribute key="duration" value="30" />
+		<attribute key="duration" value="20" />
 	</item>
 	<item id="8757" article="the" name="shadow nexus">
 		<attribute key="decayTo" value="8753" />
-		<attribute key="duration" value="20" />
+		<attribute key="duration" value="300" />
 	</item>
 	<item id="8758" article="the" name="shadow nexus">
 		<attribute key="decayTo" value="8759" />
-		<attribute key="duration" value="30" />
+		<attribute key="duration" value="20" />
 	</item>
 	<item id="8759" article="the" name="shadow nexus">
 		<attribute key="decayTo" value="8753" />
-		<attribute key="duration" value="20" />
+		<attribute key="duration" value="15" />
 	</item>
 	<item id="8760" article="a" name="valuable vase">
 		<attribute key="weight" value="1000" />

--- a/data/lib/core/storages.lua
+++ b/data/lib/core/storages.lua
@@ -2292,7 +2292,8 @@ GlobalStorage = {
 	OberonEventTime = 65009,
 	PrinceDrazzakEventTime = 65010,
 	ScarlettEtzelEventTime = 65011,
-	CobraBastionFlask = 65012
+	CobraBastionFlask = 65012,
+	Inquisition = 65013
 }
 
 


### PR DESCRIPTION
Corrigi a ultima parte, a parte referente ao Shadow Nexus, levando como base o TibiaWiki.
Como era:
-Antes o player apenas dava use no Nexus(a mw) e já era teleportado até a sala de recompensas.
Como ficou:
-Os players agora precisam usar o holy water na mw, esperando os intervalos, tal como diz o Tibia Wiki.
-Após usar o Flask as 3 vezes para chegar no ultimo estágio, os players terão 10 segundos para usar o flask novamente e conseguir a storage, porém, apenas os 4 ou 5(aleatorio) primeiros que usarem vão conseguir (tal como diz no tibia wiki).